### PR TITLE
Using uuid as filename

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "eslintIntegration": true
+}

--- a/node/package.json
+++ b/node/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "@vtex/api": "^0.40.0",
     "apollo-upload-server": "^5.0.0",
-    "ramda": "^0.25.0"
+    "ramda": "^0.25.0",
+    "uuid": "^8.2.0"
   },
   "devDependencies": {
     "@types/bluebird-global": "^3.5.12",

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from 'uuid'
 import FileManager from '../FileManager'
 
 export const resolvers = {
@@ -20,7 +21,10 @@ export const resolvers = {
     uploadFile: async (obj, args, ctx, info) => {
       const fileManager = new FileManager(ctx.vtex)
       const {file, bucket} = args
-      const {stream, filename, mimetype, encoding} = await file
+      const {stream, filename: name, mimetype, encoding} = await file
+      const [,extension] = name.split(',')
+      const filename = `${uuidv4()}.${extension}`
+
       const incomingFile = {filename, mimetype, encoding}
       return {
         encoding,

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -22,7 +22,7 @@ export const resolvers = {
       const fileManager = new FileManager(ctx.vtex)
       const {file, bucket} = args
       const {stream, filename: name, mimetype, encoding} = await file
-      const [,extension] = name.split(',')
+      const [,extension] = name.split('.')
       const filename = `${uuidv4()}.${extension}`
 
       const incomingFile = {filename, mimetype, encoding}

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -22,7 +22,7 @@ export const resolvers = {
       const fileManager = new FileManager(ctx.vtex)
       const {file, bucket} = args
       const {stream, filename: name, mimetype, encoding} = await file
-      const [,extension] = name.split('.')
+      const [extension] = name?.split('.')?.reverse()
       const filename = `${uuidv4()}.${extension}`
 
       const incomingFile = {filename, mimetype, encoding}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -551,6 +551,11 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
+uuid@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.2.0.tgz#cb10dd6b118e2dada7d0cd9730ba7417c93d920e"
+  integrity sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"


### PR DESCRIPTION
This makes Site Editor not error when the user upload a file with special characters (VBase limitation)

Related thread: https://vtex.slack.com/archives/C2WSEU9QQ/p1586289540183800

**How to test**
- Rename an image from your file system **to have an á**, for example.
- Go to: https://appliancetheme.myvtex.com/admin/cms/site-editor and try to upload it to the Carousel
- It shouldn't work ❌ 
![image](https://user-images.githubusercontent.com/18706156/87827140-9e7aac80-c850-11ea-8fb4-1c505cd8585f.png)

- Now, check it on: https://elizabeth--appliancetheme.myvtex.com/admin/cms/site-editor