### PR TITLE
fix: some valid svg files were not being uploaded due dompurify normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Validation to a valid svg file since dompurify also normalizes the string
+
 ## [0.7.3] - 2025-06-13
 
 ### Added

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -63,7 +63,11 @@ const isValidSVGFile = async (loadedFile: any) => {
       USE_PROFILES: { svg: true },
     })
         
-    return cleanSvgString === fileString
+    return (
+      typeof cleanSvgString === 'string' &&
+      cleanSvgString.trim().length > 0 &&
+      cleanSvgString.includes('<svg')
+    )
 }
 
 export const resolvers = {

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -5,6 +5,7 @@ import createDOMPurify from 'dompurify'
 import type { ServiceContext } from '@vtex/api'
 
 import FileManager from '../FileManager'
+import { Readable } from 'stream'
 
 
 type FileManagerArgs = {
@@ -52,7 +53,7 @@ const isValidFileFormat = (extension: string, mimetype: string) => {
   return normalizedExtension in allowedFileTypes && allowedFileTypes[normalizedExtension as keyof typeof allowedFileTypes] === mimetype
 }
 
-const isValidSVGFile = async (loadedFile: any) => {
+const sanitizeSvgFile = async (loadedFile: any) => {
     const fileBuffer = await loadedFile.createReadStream().toArray()
     const fileString = Buffer.concat(fileBuffer).toString('utf8')
         
@@ -62,12 +63,13 @@ const isValidSVGFile = async (loadedFile: any) => {
     const cleanSvgString = DOMPurify.sanitize(fileString, {
       USE_PROFILES: { svg: true },
     })
-        
-    return (
-      typeof cleanSvgString === 'string' &&
+    
+    return {
+      isSafe: typeof cleanSvgString === 'string' &&
       cleanSvgString.trim().length > 0 &&
-      cleanSvgString.includes('<svg')
-    )
+      cleanSvgString.includes('<svg'),
+      sanitizedContent: cleanSvgString,
+    }
 }
 
 export const resolvers = {
@@ -96,7 +98,7 @@ export const resolvers = {
     uploadFile: async (_: unknown, args: UploadFileArgs, ctx: ServiceContext) => {
       const fileManager = new FileManager(ctx.vtex)
       const { file, bucket } = args
-      const loadedFile = await file
+      let loadedFile = await file
       const {filename: name, mimetype, encoding } = loadedFile
       const [extension] = name?.split('.')?.reverse()
 
@@ -109,15 +111,18 @@ export const resolvers = {
       // and other security issues, so we check if the file is SVG
       // and sanitize it if necessary.         
 
-      if (mimetype === 'image/svg+xml') {     
-        const isSafe = await isValidSVGFile(loadedFile)
+      if (mimetype === 'image/svg+xml') {             
+        const {isSafe, sanitizedContent} = await sanitizeSvgFile(loadedFile)
           if (!isSafe) {            
             throw new Error('Invalid or malicious SVG file')
-          }   
+          }
+        const sanitizedBuffer = Buffer.from(sanitizedContent, 'utf8')
+
+        loadedFile.createReadStream = () => Readable.from(sanitizedBuffer)  
       }
 
       const filename = `${uuidv4()}.${extension}`
-      const stream = loadedFile.createReadStream(filename)
+      const stream = loadedFile.createReadStream()
 
       const incomingFile = { filename, mimetype, encoding }
 

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -114,8 +114,9 @@ export const resolvers = {
       if (mimetype === 'image/svg+xml') {             
         const {isSafe, sanitizedContent} = await sanitizeSvgFile(loadedFile)
           if (!isSafe) {            
-            throw new Error('Invalid or malicious SVG file')
+            throw new Error('Forced attempt to upload unsafe SVG file with no valid content')
           }
+          
         const sanitizedBuffer = Buffer.from(sanitizedContent, 'utf8')
 
         loadedFile.createReadStream = () => Readable.from(sanitizedBuffer)  


### PR DESCRIPTION
Dom purify also normalizes the SVG string, so we can't compare two valid strings because they might have slight differences between each other. You can now test the expected behavior with

Example: 

`<image />` or `<image prop1      prop2 / >`
to
`<image></image>` or `<image prop1 prop2></image>`

Uploadable -> <img src="https://github.com/user-attachments/assets/41b7c0be-92e1-416a-b15a-decd0de1e91b" width="20" height="20"> (if you are using dark mode, there is a svg file here)

Bugged -> ![BuggedSvgFile](https://github.com/user-attachments/assets/92fa9b7a-1da9-44ed-baa1-883963fc6d72)

workspace: https://svgbug--storecomponents.myvtex.com/admin/new-cms/media-gallery
