### PR TITLE
[STR-600] Bucket Restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Bucket restrictions when uploading files
+
 ## [0.7.4] - 2025-06-16
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,13 @@
       }
     },
     {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "{{account}}.vtexcommercestable.com.br",
+        "path": "/api/license-manager/pvt/accounts/{{account}}/products/*"
+      }
+    },
+    {
       "name": "sphinx-is-admin"
     }
   ],

--- a/node/config/allowList.ts
+++ b/node/config/allowList.ts
@@ -1,5 +1,4 @@
-export const ALLOW_LIST = [
-  'storecomponents',
+export const ALLOW_LIST = [  
   'adidasuy',
   'amakha',
   'ambientegourmetb2b',

--- a/node/config/bucketRestrictions.ts
+++ b/node/config/bucketRestrictions.ts
@@ -1,0 +1,11 @@
+export const BUCKET_RESTRICTIONS = [
+  
+  // Only users with permission to access the page that allows logo uploads
+  // can upload files to the logo bucket
+  {
+    bucket: 'logo',
+    productCode: '13', //UI resources
+    resourceCode: 'MarketplaceNetwork', //Access the Marketplace Network
+    errorMessage: 'User does not have access to upload logo files',
+  }
+]

--- a/node/directives/auth.ts
+++ b/node/directives/auth.ts
@@ -1,37 +1,74 @@
 import { defaultFieldResolver, GraphQLField } from 'graphql'
 import { SchemaDirectiveVisitor } from 'graphql-tools'
-
+import axios from 'axios'
 import { ALLOW_LIST } from '../config/allowList'
+import { BUCKET_RESTRICTIONS } from '../config/bucketRestrictions'
 
-export const authFromCookie = async (ctx: any, operationName: string) => {
-  const {
-    clients: { sphinx, vtexID },
-    vtex: { authToken },
-  } = ctx
+async function getUserEmail(ctx: any): Promise<string> {
+  const { clients: { vtexID }, vtex: { authToken } } = ctx
 
   const vtexIdToken =
     ctx.cookies.get('VtexIdclientAutCookie') ??
     ctx.request.header.vtexidclientautcookie
 
-  if (!vtexIdToken) {
-    return 'User must be logged to access this resource'
-  }
+  if (!vtexIdToken) throw new Error('User must be logged to access this resource')
 
-  const { user: email } = (await vtexID.getIdUser(vtexIdToken, authToken)) || {
-    user: '',
-  }
+  const { user: email } = (await vtexID.getIdUser(vtexIdToken, authToken)) || { user: '' }
 
-  if (!email) {
-    return 'Could not find user specified by token.'
+  if (!email) throw new Error('Could not find user specified by token.')
+
+  return email
+}
+
+async function getUserCanAccessResource(
+  authToken: string, account: string, userEmail: string, productCode: string, resourceCode: string): Promise<boolean> {
+    
+  const url = `http://${account}.vtexcommercestable.com.br/api/license-manager/pvt/accounts/${account}/products/${productCode}/logins/${userEmail}/resources/${resourceCode}/granted`
+
+  const req = await axios.request({
+    headers: { 'Authorization': authToken },
+    method: 'get',
+    url,
+  })
+  
+  return req.data
+}
+
+async function checkAuthorizationRestrictions(
+  { ctx, operationName, args, email }: { ctx: any, operationName: string, args: any, email: string }) {
+
+  const { account, authToken } = ctx.vtex
+  const { sphinx } = ctx.clients
+
+  if (operationName === 'uploadFile' && ALLOW_LIST.includes(account)) return true
+
+  if (operationName === 'uploadFile') {    
+    const restriction = BUCKET_RESTRICTIONS.find(
+      ({ bucket }) => bucket === args.bucket)
+
+    if (restriction) {
+      const canAccess = await getUserCanAccessResource(
+        authToken,
+        account,
+        email,
+        restriction.productCode,
+        restriction.resourceCode
+      )
+
+      console.log(`User ${email} can access resource: ${canAccess} - ${ restriction.productCode} - ${ 
+        restriction.resourceCode}`)
+    
+      if (canAccess) return true
+      throw new Error(restriction.errorMessage)
+    }
   }
 
   if (operationName === 'deleteFile') {
     // Only admin users can delete files
-    const isAdminUser = await sphinx.isAdmin(email)
+    const isAdmin = await sphinx.isAdmin(email)
 
-    if (!isAdminUser) {
-      return 'User is not admin and can not access resource.'
-    }
+    if (isAdmin) return true
+    throw new Error('User is not admin and can not access resource.')
   }
 
   return true
@@ -41,27 +78,11 @@ export class Authorization extends SchemaDirectiveVisitor {
   public visitFieldDefinition(field: GraphQLField<any, any>) {
     const { resolve = defaultFieldResolver } = field
 
-    // eslint-disable-next-line max-params
     field.resolve = async (root, args, ctx, info) => {
       const operationName = info.fieldName
-      let isAllowed = false
-
-      if (operationName === 'uploadFile') {
-        const isInAllowList = ALLOW_LIST.includes(ctx.vtex.account)
-
-        if (isInAllowList) {
-          isAllowed = true
-        }
-      }
-
-      if (!isAllowed) {
-        const cookieAllowsAccess = await authFromCookie(ctx, operationName)
-
-        if (cookieAllowsAccess !== true) {
-          throw new Error(cookieAllowsAccess)
-        }
-      }
-
+      const email = await getUserEmail(ctx)
+      console.log(`User email: ${email} - Operation: ${operationName}`)
+      await checkAuthorizationRestrictions({ ctx, operationName, args, email })
       return resolve(root, args, ctx, info)
     }
   }

--- a/node/directives/auth.ts
+++ b/node/directives/auth.ts
@@ -54,9 +54,6 @@ async function checkAuthorizationRestrictions(
         restriction.productCode,
         restriction.resourceCode
       )
-
-      console.log(`User ${email} can access resource: ${canAccess} - ${ restriction.productCode} - ${ 
-        restriction.resourceCode}`)
     
       if (canAccess) return true
       throw new Error(restriction.errorMessage)
@@ -81,7 +78,6 @@ export class Authorization extends SchemaDirectiveVisitor {
     field.resolve = async (root, args, ctx, info) => {
       const operationName = info.fieldName
       const email = await getUserEmail(ctx)
-      console.log(`User email: ${email} - Operation: ${operationName}`)
       await checkAuthorizationRestrictions({ ctx, operationName, args, email })
       return resolve(root, args, ctx, info)
     }


### PR DESCRIPTION
**Description**
This PR introduces bucket restriction functionality to the VTEX File Manager GraphQL wrapper. With these updates, you can now control access and define allowed operations for specific buckets, enhancing file security and management within the platform.

**Key Changes**

- Added logic for bucket restrictions.
- Updated resolvers to support new access control rules.

**Motivation**

The goal of this change is to ensure that only authorized users or services can access or manipulate files in specific buckets, preventing unauthorized access and potential data leaks.

**How to Test**

[Testing Workspace](https://testbucket--storecomponents.myvtex.com)

Perform upload, download, and listing operations on 'logo' bucket with and without this resource

<img width="532" alt="image" src="https://github.com/user-attachments/assets/7e51ca7b-50c3-4671-8297-4e98d350d4e3" />


For testing purposes, and, to do it in an easier way, you can change the logo bucket to 'images' and test it directly into media gallery: admin/new-cms/media-gallery


This is the expected error message

![image](https://github.com/user-attachments/assets/69035598-34e1-4d25-8b8b-319c4f482018)

