### PR TITLE
docs: add spec for bucket access control integration

### DIFF
--- a/specs/bucket-access-control-integration.md
+++ b/specs/bucket-access-control-integration.md
@@ -1,0 +1,283 @@
+# Bucket Access Control Integration
+
+> **Status**: Draft
+> **Created**: 2026-08-07
+> **Epic**: STR-773
+> **RFC**: Controle de Acesso a Arquivos no vtex.file-manager (Phases 4 and 9)
+> **Upstream dependency**: `vtex.file-manager` — spec `bucket-access-control` (US-2, US-4)
+
+## 1. Business Context
+
+### Problem Statement
+
+`vtex.file-manager` is introducing per-bucket access control (`readAccess`/`writeAccess`), enforced on every file operation based on the caller's authentication level (anonymous, authenticated, account-administrator). That enforcement can only classify a request correctly if it receives the real end user's token — but `file-manager-graphql` today forwards `context.authToken` (its own app/service token) as `VtexIdclientAutCookie` on every call to `vtex.file-manager`, for every file operation (`getFile`, `getFileUrl`, `uploadFile`, `deleteFile`). An app token does not correspond to any real user, so once file-manager activates enforcement, all traffic proxied through `file-manager-graphql` (Admin Panel, store-form) would be misclassified as anonymous and rejected in mass, regardless of who is actually making the request.
+
+Additionally, account administrators need a way to view and manage a bucket's access policy from the Admin Panel. `vtex.file-manager` will expose private REST APIs (`/policies/*`) for this, but the Admin Panel only talks to VTEX IO services through GraphQL — `file-manager-graphql` needs to expose the equivalent operations as a thin proxy.
+
+This spec covers both parts, exclusively owned by `file-manager-graphql`, of the cross-repo rollout: correct token forwarding (a blocking prerequisite for file-manager's enforcement) and the GraphQL surface for bucket policy management (consumed by the Admin Panel, out of this spec's scope).
+
+### Goals
+
+- Every file operation forwarded to `vtex.file-manager` carries the real end user's token (`userAuthToken`) instead of the app's own token, with no exceptions and no parallel code path still using the app token.
+- Anonymous callers (no user token in context) are still correctly represented as anonymous downstream — never silently rejected because the header defaulted to an app token.
+- Account administrators can list, inspect, set, and remove a bucket's admin access policy via GraphQL, as a thin proxy over file-manager's private `/policies/*` APIs, with no independent authorization logic duplicated in this app.
+- `403 Forbidden` responses from file-manager (permission or immutable-bucket errors) are surfaced to the GraphQL caller as-is, not swallowed or reshaped into a generic error.
+
+### User Stories
+
+#### US-1: Forward the real user token on every file operation
+
+- **Story**: As `vtex.file-manager`'s access-control enforcement, I want `file-manager-graphql` to forward the real authenticated user's token on every file operation, so that I can correctly classify each request as anonymous, authenticated, or account-administrator instead of treating all proxied traffic as anonymous.
+- **Scope note**: the header (`VtexIdclientAutCookie`) already exists in the communication between the two services today — no new header is introduced. Only the *source* of its value changes, in a single place (`FileManager` client constructor), which is shared by every file operation (`getFile`, `getFileUrl`, `uploadFile`, `deleteFile`).
+- **Acceptance Criteria**:
+  - **Given** an authenticated user uploads a file via `store-form`/Admin Panel, **when** `file-manager-graphql` forwards the request to `vtex.file-manager`, **then** the `VtexIdclientAutCookie` header carries `context.userAuthToken`, not `context.authToken`.
+  - **Given** an anonymous caller (no user token present in `ctx.vtex`), **when** any file mutation or query is called, **then** the `VtexIdclientAutCookie` header is omitted from the call to file-manager (file-manager already treats a missing credential as anonymous).
+  - **Given** any file operation (`getFile`, `getFileUrl`, `uploadFile`, `deleteFile`), **when** it is forwarded to file-manager, **then** the same token-forwarding rule is applied uniformly — there is no operation still using `context.authToken`.
+  - **Given** an account whose allow list (`config/allowList.ts`) exempts `uploadFile` from the login requirement, **when** an anonymous upload happens for that account, **then** the token-forwarding change does not alter that existing allow-list exemption — it only changes which token is forwarded when one is present.
+
+#### US-2: Read bucket policies via GraphQL
+
+- **Story**: As an account administrator using the Admin Panel, I want to list all configured bucket policies and inspect a single bucket's policy, so that I can review the current access configuration before changing it.
+- **Acceptance Criteria**:
+  - **Given** an admin with the `file-manager-bucket-config` resource, **when** they query `listBucketPolicies`, **then** the query proxies `GET /policies` on file-manager and returns every configured bucket with `effectivePolicy`, `manifestPolicy`, and `adminPolicy`, paginating through file-manager's `nextMarker` until every page is consumed, so the GraphQL caller receives a single complete list without needing to know about file-manager's internal pagination.
+  - **Given** an admin with the `file-manager-bucket-config` resource, **when** they query `getBucketPolicy(bucket)`, **then** the query proxies `GET /policies/{bucket}` and returns `effectivePolicy`, `manifestPolicy`, and `adminPolicy` for that bucket (`null` for unconfigured sources).
+  - **Given** an admin without the `file-manager-bucket-config` resource, **when** they call either query, **then** the `403 Forbidden` returned by file-manager is surfaced to the GraphQL caller as-is — `file-manager-graphql` performs no independent permission check of its own.
+
+#### US-3: Write and remove a bucket's admin policy via GraphQL
+
+- **Story**: As an account administrator using the Admin Panel, I want to set or remove a bucket's admin access policy, so that I can override its default or manifest-declared access levels.
+- **Acceptance Criteria**:
+  - **Given** an admin with the `file-manager-bucket-config` resource and an unprotected bucket, **when** they call `setBucketPolicy(bucket, readAccess, writeAccess)`, **then** the mutation proxies `POST /policies/{bucket}/admin` and returns the written `adminPolicy` with `updatedAt`/`updatedBy`.
+  - **Given** an admin with the `file-manager-bucket-config` resource and an unprotected bucket, **when** they call `deleteBucketPolicy(bucket)`, **then** the mutation proxies `DELETE /policies/{bucket}/admin` and returns confirmation (`bucket`, `removedAt`).
+  - **Given** one of the three protected buckets (`vtex-assets-builder`, `vtex.catalog-images-products`, `vtex.file-manager-graphql-logo`), **when** `setBucketPolicy` or `deleteBucketPolicy` is called for it, **then** the `403 Forbidden: "bucket policy is immutable"` returned by file-manager is surfaced to the caller unchanged.
+  - **Given** an admin without the `file-manager-bucket-config` resource, **when** they call `setBucketPolicy` or `deleteBucketPolicy`, **then** the `403 Forbidden` from file-manager is surfaced as-is.
+  - **Given** any of these mutations, **when** they are added to the schema, **then** `POST /policies/{bucket}/manifest` is **not** exposed through GraphQL at all — that route is exclusive to builder-hub's service-token flow, not the Admin Panel.
+
+### Key Scenarios
+
+| Scenario | Pre-conditions | Steps | Expected Result |
+|---|---|---|---|
+| Happy path — authenticated upload | Logged-in user, bucket with `writeAccess: authenticated` | User uploads a file via Admin Panel; `file-manager-graphql` forwards the request | `VtexIdclientAutCookie` carries `userAuthToken`; file-manager accepts the upload as an authenticated request |
+| Error — admin sets policy on a protected bucket | Admin with `file-manager-bucket-config`, bucket = `vtex-assets-builder` | Admin calls `setBucketPolicy("vtex-assets-builder", ...)` | GraphQL mutation returns the file-manager `403 Forbidden: "bucket policy is immutable"` unchanged |
+| Edge case — anonymous read with no user token | Anonymous visitor, bucket with `readAccess: public` | Visitor calls `getFile` with no session | `VtexIdclientAutCookie` header is omitted entirely; file-manager treats the request as anonymous and serves the public file |
+
+### Functional Requirements
+
+- Every call to `vtex.file-manager` for a file operation forwards `context.userAuthToken` as `VtexIdclientAutCookie`, omitting the header when no user token is present.
+- New GraphQL operations `listBucketPolicies`, `getBucketPolicy`, `setBucketPolicy`, `deleteBucketPolicy` proxy file-manager's `/policies/*` APIs (excluding `/manifest`) with no independent permission logic.
+- `listBucketPolicies` transparently paginates file-manager's `nextMarker` and returns a single complete list to the GraphQL caller.
+- Every `403 Forbidden` (or other error) returned by file-manager for a `/policies/*` call is surfaced to the GraphQL caller, not swallowed or replaced by a generic error.
+
+### Non-Functional Requirements
+
+- The token-forwarding change (US-1) must not introduce a new outbound-access policy — the header target (`vtex.file-manager`) and its credential mechanism are unchanged; only the token value's source changes.
+- The new `/policies/*` proxy methods must reuse the same `ExternalClient`/`FileManager` HTTP infrastructure already used for file operations, not introduce a second client.
+- `listBucketPolicies` must not perform N+1 calls — it is one or more calls to `GET /policies` (paginated), never one call per bucket.
+
+### Out of Scope
+
+- Any change inside `vtex.file-manager` itself — this spec only consumes its existing/planned `/policies/*` and file APIs, documented in `vtex.file-manager`'s `bucket-access-control` spec (US-2, US-4).
+- `POST /policies/{bucket}/manifest` — exclusive to builder-hub's service-token flow (see the `builder-hub` spec `file-manager-bucket-policy-integration`), never exposed via GraphQL here.
+- Admin Panel UI/UX for bucket policy management (RFC Phase 10) — this spec only exposes the GraphQL contract it will consume.
+- Activation of `vtex.file-manager`'s hot-path enforcement (US-4) in production — that activation gate depends on this spec's US-1 being completed and deployed, among other cross-repo tasks, but is decided and executed by the file-manager team.
+- Any change to the existing Sphinx-admin/`@requiresAuth` authorization layer used by `uploadFile`/`deleteFile` today — the new `/policies/*` operations rely exclusively on file-manager's own LicenseManager check, not on this app's Sphinx integration.
+
+---
+
+## 2. Arch Decisions
+
+### Proposed Solution
+
+Two independent, additive changes to the existing `FileManager` `ExternalClient`:
+
+1. **Token forwarding**: change the single header-construction site in `FileManager`'s constructor from `context.authToken` to `context.userAuthToken`, with conditional inclusion (omit the header entirely when the token is absent) instead of forwarding an `undefined`/empty value.
+2. **Policy proxy**: add four new HTTP methods to `FileManager` (`listPolicies`, `getPolicy`, `setAdminPolicy`, `deleteAdminPolicy`), four new resolvers (`listBucketPolicies`, `getBucketPolicy`, `setBucketPolicy`, `deleteBucketPolicy`), and the corresponding GraphQL schema types/fields — following the exact same three-step pattern (schema → client method → resolver) already used for `uploadFile`/`getFile`/`deleteFile`.
+
+### Architecture Overview
+
+```mermaid
+flowchart TD
+    subgraph gql [file-manager-graphql]
+        R1["getFile / getFileUrl / uploadFile / deleteFile resolvers"]
+        R2["listBucketPolicies / getBucketPolicy resolvers"]
+        R3["setBucketPolicy / deleteBucketPolicy resolvers"]
+        FM["FileManager (ExternalClient)"]
+    end
+    subgraph fm [vtex.file-manager]
+        FILE["/assets/* file routes"]
+        POL["/policies/* routes"]
+    end
+
+    R1 -->|"VtexIdclientAutCookie: userAuthToken (or omitted)"| FM
+    R2 -->|"VtexIdclientAutCookie: userAuthToken"| FM
+    R3 -->|"VtexIdclientAutCookie: userAuthToken"| FM
+    FM -->|"HTTP"| FILE
+    FM -->|"HTTP, paginated via marker"| POL
+    POL -->|"403 as-is"| FM
+    FM -->|"403 as-is"| R2
+    FM -->|"403 as-is"| R3
+```
+
+### Alternatives Considered
+
+| Alternative | Pros | Cons | Verdict |
+|---|---|---|---|
+| Fall back to `context.authToken` when `userAuthToken` is absent, instead of omitting the header | Preserves current behavior for callers that never had a user session | Reintroduces exactly the bug this spec fixes — file-manager would classify an app-token request as if it belonged to a real (anonymous-looking) user, defeating the purpose of the change | Rejected — omitting the header is the correct anonymous representation, matching file-manager's own convention |
+| Add `/policies/*` proxy methods to a brand-new client instead of extending `FileManager` | Clean separation of "file" vs. "policy" concerns | Duplicates HTTP/base-URL/error-handling setup already correct in `FileManager`; file-manager exposes both concerns from the same base URL and service | Rejected — no architectural boundary in file-manager itself justifies a second client here |
+| Implement authorization checks for `/policies/*` inside `file-manager-graphql` (e.g. reusing Sphinx) | Faster failure without a round trip to file-manager | Duplicates a permission decision that file-manager already makes via LicenseManager; risks the two authorization sources disagreeing | Rejected — matches the RFC's explicit design: file-manager-graphql performs no independent permission logic for `/policies/*` |
+
+### Risks & Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|---|---|---|---|
+| US-1 ships before `vtex.file-manager`'s hot-path enforcement (US-4) is active | None — file-manager currently accepts any token value; forwarding a different (correct) token has no behavioral effect until enforcement is activated | High (expected sequencing) | Safe to deploy independently; US-1 is a prerequisite for file-manager's activation gate, not something that itself needs a feature flag |
+| Some existing caller path relies on `context.authToken` implicitly granting elevated access to file-manager today (since app tokens are not currently distinguished from user tokens) | Medium — if any current flow depends on the app-token side effect, that flow could start behaving differently in this app once file-manager activates enforcement | Low (file-manager's own spec does not describe today's access as differentiated by token type) | Covered by file-manager's own activation-gate risk register; this spec only ensures correct token *type* is sent, not a new business rule in this app |
+| `/policies/*` proxy resolvers get out of sync with file-manager's schema (e.g. a new field added to `BucketPolicy`) | Low | Medium (two independently versioned repos) | This app declares an explicit `dependencies: { "vtex.file-manager": "0.x" }` pin (already the case); schema changes on either side go through their own spec/PR review |
+
+### Key Decisions
+
+#### Decision 1: Omit the header rather than send an empty/undefined token
+
+- **Status**: Accepted
+- **Context**: `context.userAuthToken` may be `undefined` for anonymous callers. `vtex.file-manager` already interprets the complete absence of `VtexIdclientAutCookie` as anonymous (per its own spec, US-4 AC on missing header).
+- **Decision**: `FileManager`'s constructor only includes the `VtexIdclientAutCookie` header when `context.userAuthToken` is truthy; when absent, the header key itself is omitted from the request, not sent with an empty string.
+- **Consequences**: Matches file-manager's documented anonymous-detection behavior exactly; avoids ambiguity between "header present but empty" and "header absent", which file-manager's contract does not promise to treat identically.
+
+#### Decision 2: `/policies/*` proxy methods live on the existing `FileManager` client, not a new client
+
+- **Status**: Accepted
+- **Context**: `FileManager` already encapsulates the base URL, credential header, and `ExternalClient` plumbing for `vtex.file-manager`. There is no existing precedent in this repo for splitting one downstream service across two client classes.
+- **Decision**: Add `listPolicies`, `getPolicy`, `setAdminPolicy`, `deleteAdminPolicy` as additional public methods on `FileManager`, reusing its constructor, base path, and header setup.
+- **Consequences**: Keeps a single source of truth for how this app talks to file-manager; new methods automatically inherit the corrected token-forwarding behavior from Decision 1.
+
+#### Decision 3: Downstream errors (including `403`) are rethrown as-is for `/policies/*`, mirroring `getFile`'s pattern
+
+- **Status**: Accepted
+- **Context**: The repo has two existing error-handling patterns: `getFile`/`getFileUrl`/`deleteFile` rethrow file-manager's error as-is (except mapping `404` to a local `FileNotFound`); `saveFile` always wraps errors into `InternalServerError`, which would obscure a `403` as a generic 500-family error.
+- **Decision**: The new `/policies/*` methods follow the rethrow-as-is pattern (no `404`-style remapping needed, since file-manager's policy routes do not define a `404` semantic for this flow) — a file-manager `403` propagates to the GraphQL layer with its original status and message intact.
+- **Consequences**: Admin Panel receives the exact reason for a rejection (e.g. `"bucket policy is immutable"`) instead of a generic failure; avoids reusing the `saveFile`-style wrapper, which was designed for upload-specific failure semantics, not permission decisions.
+
+#### Decision 4: No new `@requiresAuth`/Sphinx layer for `/policies/*` operations
+
+- **Status**: Accepted
+- **Context**: `deleteFile` today additionally requires Sphinx admin, on top of `@requiresAuth`. The RFC and file-manager's own spec assign `/policies/*` authorization exclusively to LicenseManager's `file-manager-bucket-config` resource, checked with the forwarded `VtexIdclientAutCookie` (Decision 8/9 of file-manager's spec).
+- **Decision**: `listBucketPolicies`, `getBucketPolicy`, `setBucketPolicy`, `deleteBucketPolicy` resolvers apply `@requiresAuth` (so an anonymous caller is rejected at the GraphQL layer before even reaching file-manager) but do **not** add a Sphinx admin check — the account-administrator decision belongs entirely to file-manager's LicenseManager check.
+- **Consequences**: Avoids a second, possibly inconsistent, authorization source; `@requiresAuth` here is purely a "must be logged in" gate, not an "is admin" gate — file-manager's `403` is the actual admin-permission signal.
+
+### Implementation Plan
+
+```mermaid
+graph LR
+    US1["US-1: Token forwarding fix"] -.->|independent| US2["US-2: Read GraphQL ops"]
+    US2 --> US3["US-3: Write GraphQL ops"]
+```
+
+1. **US-1** — change the header source in `FileManager`'s constructor; add/adjust unit tests covering the presence and absence of `userAuthToken`. Deployable independently and immediately, with no dependency on file-manager's own rollout status.
+2. **US-2** — add `listPolicies`/`getPolicy` methods to `FileManager`, the corresponding schema types (`BucketPolicy`, `BucketPolicyView`) and `Query` fields, and resolvers. Requires `vtex.file-manager`'s US-2 (`/policies/*` APIs) already deployed to be tested end-to-end (can still be implemented and unit-tested with mocks beforehand).
+3. **US-3** — add `setAdminPolicy`/`deleteAdminPolicy` methods, `Mutation` fields, and resolvers, reusing US-2's types.
+
+---
+
+## 3. Technical Contract
+
+### Data Models
+
+GraphQL schema additions (`graphql/schema.graphql`):
+
+```graphql
+enum AccessLevel {
+  PUBLIC
+  AUTHENTICATED
+  ACCOUNT_ADMINISTRATOR
+}
+
+type BucketPolicy {
+  readAccess: AccessLevel!
+  writeAccess: AccessLevel!
+  updatedAt: String
+  updatedBy: String
+}
+
+type BucketPolicyView {
+  bucket: String!
+  effectivePolicy: BucketPolicy!
+  manifestPolicy: BucketPolicy
+  adminPolicy: BucketPolicy
+}
+
+extend type Query {
+  listBucketPolicies: [BucketPolicyView!]! @requiresAuth
+  getBucketPolicy(bucket: String!): BucketPolicyView @requiresAuth
+}
+
+extend type Mutation {
+  setBucketPolicy(bucket: String!, readAccess: AccessLevel!, writeAccess: AccessLevel!): BucketPolicy @requiresAuth
+  deleteBucketPolicy(bucket: String!): Boolean! @requiresAuth
+}
+```
+
+### Interfaces
+
+New `FileManager` client methods (`node/FileManager.ts`), alongside the existing `getFile`/`getFileUrl`/`saveFile`/`deleteFile`:
+
+```
+listPolicies(marker?: string): Promise<{ policies: BucketPolicyView[]; nextMarker: string | null }>
+  → GET /policies?marker={marker}
+
+getPolicy(bucket: string): Promise<BucketPolicyView | null>
+  → GET /policies/{bucket}
+
+setAdminPolicy(bucket: string, readAccess: AccessLevel, writeAccess: AccessLevel): Promise<BucketPolicy>
+  → POST /policies/{bucket}/admin, body { readAccess, writeAccess }
+
+deleteAdminPolicy(bucket: string): Promise<{ bucket: string; removedAt: string }>
+  → DELETE /policies/{bucket}/admin
+```
+
+Updated constructor (`node/FileManager.ts`), replacing the current hardcoded `context.authToken`:
+
+```
+headers: {
+  ...(options?.headers ?? {}),
+  ...(context.userAuthToken ? { VtexIdclientAutCookie: context.userAuthToken } : {}),
+  'Content-Type': 'application/json',
+  'X-Vtex-Use-Https': 'true',
+}
+```
+
+Resolvers (`node/resolvers/index.ts`), following the existing pattern:
+
+```
+listBucketPolicies: async (_: unknown, __: unknown, ctx: ServiceContext) => {
+  const fileManager = new FileManager(ctx.vtex)
+  // paginate via nextMarker until exhausted, concatenating `policies`
+}
+
+getBucketPolicy: async (_: unknown, args: { bucket: string }, ctx: ServiceContext) => {
+  const fileManager = new FileManager(ctx.vtex)
+  return fileManager.getPolicy(args.bucket)
+}
+
+setBucketPolicy: async (_: unknown, args: SetBucketPolicyArgs, ctx: ServiceContext) => {
+  const fileManager = new FileManager(ctx.vtex)
+  return fileManager.setAdminPolicy(args.bucket, args.readAccess, args.writeAccess)
+}
+
+deleteBucketPolicy: async (_: unknown, args: { bucket: string }, ctx: ServiceContext) => {
+  const fileManager = new FileManager(ctx.vtex)
+  await fileManager.deleteAdminPolicy(args.bucket)
+  return true
+}
+```
+
+### Integration Points
+
+- **`vtex.file-manager`** (existing dependency, `dependencies: { "vtex.file-manager": "0.x" }` in `manifest.json`): all four file operations plus the four new `/policies/*` operations, over the existing `ExternalClient` base URL.
+- **Admin Panel** (consumer, out of scope): will call `listBucketPolicies`, `getBucketPolicy`, `setBucketPolicy`, `deleteBucketPolicy` through this app's GraphQL schema — this spec only guarantees the contract exists and behaves as documented above.
+
+### Invariants & Constraints
+
+- `VtexIdclientAutCookie` is never populated from `context.authToken` for any file or policy operation after this spec is implemented.
+- `POST /policies/{bucket}/manifest` is never reachable through this app's GraphQL schema.
+- Every `403`/error returned by `vtex.file-manager` for a `/policies/*` call reaches the GraphQL caller with its original message and status, never replaced by a generic `InternalServerError`.
+- `listBucketPolicies` always returns a fully paginated, deduplicated list — it never silently returns only the first page.

--- a/specs/review-bucket-access-control-integration.html
+++ b/specs/review-bucket-access-control-integration.html
@@ -1,0 +1,803 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Bucket Access Control Integration — Review Canvas</title>
+<style>
+:root {
+  --bg: #0d0f18;
+  --surface: #13161f;
+  --surface2: #1c2030;
+  --border: #252b3b;
+  --border2: #303650;
+  --text: #dde3f0;
+  --muted: #6b7694;
+  --accent: #6366f1;
+  --accent2: #818cf8;
+  --green: #22c55e;
+  --amber: #f59e0b;
+  --red: #ef4444;
+  --blue: #60a5fa;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  display: flex;
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+/* ── Progress bar ── */
+#reading-bar {
+  position: fixed; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--border); z-index: 100;
+}
+#reading-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  width: 0%; transition: width .2s ease;
+}
+
+/* ── Sidebar nav ── */
+.sidenav {
+  position: fixed; left: 0; top: 0; bottom: 0;
+  width: 220px; background: var(--surface);
+  border-right: 1px solid var(--border);
+  padding: 52px 0 32px;
+  display: flex; flex-direction: column; gap: 2px;
+  overflow-y: auto;
+  z-index: 50;
+}
+
+.nav-label {
+  font-size: 10px; font-weight: 600; letter-spacing: .08em;
+  color: var(--muted); text-transform: uppercase;
+  padding: 8px 20px 6px;
+}
+
+.nav-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 20px;
+  cursor: pointer;
+  font-size: 13px; color: var(--muted);
+  border-left: 2px solid transparent;
+  transition: all .15s;
+}
+.nav-item:hover { color: var(--text); background: var(--surface2); }
+.nav-item.active { color: var(--accent2); border-left-color: var(--accent); background: rgba(99,102,241,.08); font-weight: 500; }
+.nav-item.visited .nav-dot { background: var(--green); }
+
+.nav-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--border2); flex-shrink: 0;
+  transition: background .3s;
+}
+
+.nav-progress {
+  margin-top: auto; padding: 20px 20px 0;
+  border-top: 1px solid var(--border);
+}
+.nav-prog-label { font-size: 11px; color: var(--muted); margin-bottom: 6px; }
+.nav-prog-bar { height: 4px; background: var(--border); border-radius: 99px; overflow: hidden; }
+.nav-prog-fill { height: 100%; background: var(--accent); border-radius: 99px; transition: width .4s; }
+.nav-prog-count { font-size: 11px; color: var(--muted); margin-top: 5px; }
+
+/* ── Main canvas ── */
+.canvas {
+  margin-left: 220px;
+  flex: 1;
+  padding: 48px 56px 100px;
+  max-width: 960px;
+}
+
+/* ── Panels ── */
+.panel {
+  margin-bottom: 72px;
+  scroll-margin-top: 32px;
+}
+
+.panel-eyebrow {
+  font-size: 11px; font-weight: 600; letter-spacing: .1em;
+  text-transform: uppercase; color: var(--accent2);
+  margin-bottom: 10px;
+}
+
+.panel-title {
+  font-size: 26px; font-weight: 700; letter-spacing: -.4px;
+  margin-bottom: 6px;
+}
+
+.panel-sub {
+  font-size: 14px; color: var(--muted); line-height: 1.6;
+  margin-bottom: 28px;
+  max-width: 640px;
+}
+
+/* ── Overview ── */
+.overview-meta {
+  display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 28px;
+}
+.pill {
+  padding: 4px 12px; border-radius: 99px; font-size: 12px; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 5px;
+}
+.pill-draft  { background: rgba(245,158,11,.12); color: var(--amber); border: 1px solid rgba(245,158,11,.25); }
+.pill-epic   { background: rgba(96,165,250,.1); color: var(--blue);  border: 1px solid rgba(96,165,250,.2); }
+.pill-scope  { background: var(--surface2); color: var(--muted); border: 1px solid var(--border); }
+
+.tldr-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 24px 28px;
+  margin-bottom: 28px;
+}
+.tldr-title { font-size: 12px; font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: .07em; margin-bottom: 14px; }
+.tldr-item {
+  display: flex; gap: 12px; align-items: flex-start;
+  padding: 8px 0; border-bottom: 1px solid var(--border);
+  font-size: 14px; line-height: 1.5;
+}
+.tldr-item:last-child { border-bottom: none; }
+.tldr-bullet {
+  width: 20px; height: 20px; border-radius: 6px;
+  flex-shrink: 0; display: flex; align-items: center; justify-content: center;
+  font-size: 12px; margin-top: 1px;
+}
+.b-problem { background: rgba(239,68,68,.15); }
+.b-solution { background: rgba(99,102,241,.15); }
+.b-constraint { background: rgba(245,158,11,.12); }
+.b-scope { background: rgba(96,165,250,.1); }
+
+/* Flow chain */
+.chain-wrap { display: flex; align-items: stretch; gap: 0; margin-top: 4px; }
+.chain-node {
+  flex: 1;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px 14px;
+  position: relative;
+}
+.chain-num {
+  width: 22px; height: 22px; border-radius: 6px; background: var(--accent);
+  font-size: 11px; font-weight: 700;
+  display: flex; align-items: center; justify-content: center;
+  margin-bottom: 8px;
+}
+.chain-name { font-size: 12px; font-weight: 600; color: var(--text); margin-bottom: 3px; }
+.chain-detail { font-size: 11px; color: var(--muted); line-height: 1.4; }
+.chain-arrow {
+  display: flex; align-items: center;
+  padding: 0 4px;
+  color: var(--border2); font-size: 16px;
+  flex-shrink: 0; align-self: center;
+}
+
+/* ── User Stories ── */
+.story-grid {
+  display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px;
+}
+.story-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 18px 20px;
+  cursor: pointer;
+  transition: border-color .15s, background .15s;
+}
+.story-card:hover { border-color: var(--border2); background: var(--surface2); }
+.story-card.open { border-color: var(--accent); }
+.story-header { display: flex; gap: 10px; align-items: flex-start; margin-bottom: 8px; }
+.story-tag {
+  font-size: 11px; font-weight: 700; color: var(--accent2);
+  background: rgba(99,102,241,.12); border-radius: 5px;
+  padding: 2px 7px; flex-shrink: 0; margin-top: 1px;
+}
+.story-title { font-size: 13.5px; font-weight: 600; line-height: 1.35; }
+.story-role { font-size: 12px; color: var(--muted); margin-bottom: 8px; }
+.story-acs { display: none; margin-top: 12px; border-top: 1px solid var(--border); padding-top: 12px; }
+.story-card.open .story-acs { display: block; }
+.story-ac {
+  font-size: 12px; color: var(--muted); line-height: 1.5;
+  padding: 4px 0; display: flex; gap: 8px;
+}
+.story-ac::before { content: "→"; color: var(--accent); flex-shrink: 0; }
+.story-expand { font-size: 11px; color: var(--accent2); margin-top: 6px; }
+
+/* ── Architecture ── */
+.arch-section-title { font-size: 12px; font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: .07em; margin: 24px 0 12px; }
+
+.bucket-block {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 12px; padding: 16px 20px; margin-bottom: 12px;
+}
+.bucket-row { display: flex; align-items: center; gap: 12px; }
+.bucket-icon { font-size: 18px; }
+.bucket-name { font-size: 14px; font-weight: 600; }
+.bucket-path { font-size: 12px; color: var(--muted); font-family: 'SF Mono', monospace; }
+.bucket-badge { margin-left: auto; }
+
+.policy-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.policy-table th { text-align: left; padding: 8px 12px; color: var(--muted); font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .06em; border-bottom: 1px solid var(--border); }
+.policy-table td { padding: 10px 12px; border-bottom: 1px solid rgba(37,43,59,.5); }
+.policy-table tr:last-child td { border-bottom: none; }
+.policy-table tr:hover td { background: rgba(255,255,255,.015); }
+
+.level-badge {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 9px; border-radius: 99px; font-size: 11px; font-weight: 500;
+}
+.level-public    { background: rgba(34,197,94,.12);  color: var(--green); border: 1px solid rgba(34,197,94,.25); }
+.level-auth      { background: rgba(96,165,250,.1);  color: var(--blue);  border: 1px solid rgba(96,165,250,.2); }
+.level-admin     { background: rgba(245,158,11,.1);  color: var(--amber); border: 1px solid rgba(245,158,11,.2); }
+.level-immutable { background: rgba(239,68,68,.1);   color: var(--red);   border: 1px solid rgba(239,68,68,.2); }
+
+/* ── Decisions ── */
+.decisions-list { display: flex; flex-direction: column; gap: 10px; }
+.decision-card {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 12px; padding: 16px 20px;
+  cursor: pointer; transition: border-color .15s;
+}
+.decision-card:hover { border-color: var(--border2); }
+.decision-card.open { border-color: var(--accent); }
+.decision-header { display: flex; align-items: center; gap: 12px; }
+.decision-n {
+  width: 26px; height: 26px; border-radius: 7px;
+  background: var(--surface2); border: 1px solid var(--border2);
+  font-size: 12px; font-weight: 700; display: flex;
+  align-items: center; justify-content: center; flex-shrink: 0;
+  color: var(--accent2);
+}
+.decision-title { font-size: 14px; font-weight: 600; flex: 1; }
+.decision-status {
+  font-size: 11px; padding: 2px 9px; border-radius: 99px; font-weight: 500;
+  background: rgba(34,197,94,.1); color: var(--green); border: 1px solid rgba(34,197,94,.2);
+  flex-shrink: 0;
+}
+.decision-chevron { color: var(--muted); font-size: 12px; transition: transform .2s; }
+.decision-card.open .decision-chevron { transform: rotate(180deg); }
+.decision-body {
+  display: none; margin-top: 14px; border-top: 1px solid var(--border);
+  padding-top: 14px; font-size: 13px; color: var(--muted); line-height: 1.6;
+}
+.decision-card.open .decision-body { display: block; }
+.decision-field { margin-bottom: 8px; }
+.decision-field strong { color: var(--text); font-weight: 500; }
+
+/* ── Risks ── */
+.risk-grid {
+  display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px;
+}
+.risk-card {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 12px; padding: 16px 18px;
+}
+.risk-badges { display: flex; gap: 6px; margin-bottom: 10px; }
+.risk-title { font-size: 13.5px; font-weight: 600; margin-bottom: 6px; }
+.risk-mitigation { font-size: 12px; color: var(--muted); line-height: 1.5; }
+.badge-impact, .badge-likelihood {
+  font-size: 11px; font-weight: 600; padding: 2px 8px;
+  border-radius: 99px;
+}
+.high   { background: rgba(239,68,68,.12);  color: var(--red);   border: 1px solid rgba(239,68,68,.2); }
+.medium { background: rgba(245,158,11,.1);  color: var(--amber); border: 1px solid rgba(245,158,11,.2); }
+.low    { background: rgba(34,197,94,.1);   color: var(--green); border: 1px solid rgba(34,197,94,.2); }
+
+/* ── API ── */
+.endpoint-list { display: flex; flex-direction: column; gap: 10px; }
+.endpoint {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 12px; padding: 16px 20px;
+  display: flex; align-items: flex-start; gap: 14px;
+}
+.method {
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 11px; font-weight: 700;
+  padding: 3px 9px; border-radius: 6px; flex-shrink: 0; margin-top: 1px;
+}
+.m-get    { background: rgba(34,197,94,.12); color: var(--green); }
+.m-post   { background: rgba(96,165,250,.1); color: var(--blue); }
+.m-delete { background: rgba(239,68,68,.1);  color: var(--red); }
+.endpoint-path {
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 13.5px; font-weight: 600; margin-bottom: 4px;
+}
+.endpoint-desc { font-size: 12px; color: var(--muted); line-height: 1.5; }
+.endpoint-codes { display: flex; gap: 6px; margin-top: 8px; flex-wrap: wrap; }
+.code-badge {
+  font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 5px;
+  font-family: monospace;
+}
+.c200 { background: rgba(34,197,94,.1);  color: var(--green); }
+.c403 { background: rgba(239,68,68,.1);  color: var(--red); }
+.c401 { background: rgba(245,158,11,.1); color: var(--amber); }
+
+/* ── Gap ── */
+.gap-card {
+  background: rgba(245,158,11,.06);
+  border: 1px solid rgba(245,158,11,.3);
+  border-radius: 14px; padding: 24px 28px;
+  margin-bottom: 16px;
+}
+.gap-label {
+  font-size: 11px; font-weight: 700; letter-spacing: .08em;
+  text-transform: uppercase; color: var(--amber); margin-bottom: 8px;
+}
+.gap-title { font-size: 18px; font-weight: 700; margin-bottom: 10px; }
+.gap-body { font-size: 14px; color: #c9a044; line-height: 1.6; margin-bottom: 16px; }
+.gap-fix {
+  background: rgba(0,0,0,.3); border-radius: 8px;
+  padding: 14px 18px;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 12px; color: #d4a853; line-height: 1.7;
+  white-space: pre-wrap;
+}
+.gap-card.resolved {
+  background: rgba(34,197,94,.06); border-color: rgba(34,197,94,.3);
+}
+.gap-card.resolved .gap-label { color: var(--green); }
+
+/* ── Divider ── */
+.section-divider { height: 1px; background: var(--border); margin: 0 0 72px; }
+</style>
+</head>
+<body>
+
+<div id="reading-bar"><div id="reading-fill"></div></div>
+
+<!-- Sidebar -->
+<nav class="sidenav">
+  <div class="nav-label">Seções</div>
+  <div class="nav-item active" data-target="overview">
+    <span class="nav-dot"></span>Visão Geral
+  </div>
+  <div class="nav-item" data-target="stories">
+    <span class="nav-dot"></span>User Stories
+  </div>
+  <div class="nav-item" data-target="architecture">
+    <span class="nav-dot"></span>Arquitetura
+  </div>
+  <div class="nav-item" data-target="decisions">
+    <span class="nav-dot"></span>Key Decisions
+  </div>
+  <div class="nav-item" data-target="risks">
+    <span class="nav-dot"></span>Riscos
+  </div>
+  <div class="nav-item" data-target="api">
+    <span class="nav-dot"></span>Superfície GraphQL
+  </div>
+  <div class="nav-item" data-target="gap">
+    <span class="nav-dot"></span>⚠ Gap encontrado
+  </div>
+
+  <div class="nav-progress">
+    <div class="nav-prog-label">Progresso de leitura</div>
+    <div class="nav-prog-bar"><div class="nav-prog-fill" id="nav-fill" style="width:0%"></div></div>
+    <div class="nav-prog-count" id="nav-count">0 / 7 seções</div>
+  </div>
+</nav>
+
+<!-- Canvas -->
+<main class="canvas">
+
+  <!-- 1. Visão Geral -->
+  <section class="panel" id="overview">
+    <div class="panel-eyebrow">Spec · Draft · STR-773</div>
+    <div class="panel-title">Bucket Access Control Integration</div>
+    <div class="panel-sub">Encaminhamento correto de token de usuário e superfície GraphQL de política de bucket no file-manager-graphql — cobrindo as Fases 4 e 9 da RFC.</div>
+
+    <div class="overview-meta">
+      <span class="pill pill-draft">● Draft</span>
+      <span class="pill pill-epic">STR-773</span>
+      <span class="pill pill-scope">Fases 4, 9</span>
+      <span class="pill pill-scope">3 User Stories</span>
+      <span class="pill pill-scope">4 Key Decisions</span>
+      <span class="pill pill-scope" style="color:var(--green);border-color:rgba(34,197,94,.25)">✓ revisado 2026-08-07</span>
+    </div>
+
+    <div class="tldr-card">
+      <div class="tldr-title">TL;DR</div>
+      <div class="tldr-item">
+        <div class="tldr-bullet b-problem">🔓</div>
+        <div><strong>Problema:</strong> o file-manager-graphql hoje encaminha context.authToken (token da própria app) em toda chamada ao file-manager — isso impede o file-manager de distinguir anônimo/autenticado/admin, e vai rejeitar em massa o tráfego via Admin Panel/store-form quando o enforcement for ativado.</div>
+      </div>
+      <div class="tldr-item">
+        <div class="tldr-bullet b-solution">🔧</div>
+        <div><strong>Solução:</strong> trocar a origem do header VtexIdclientAutCookie para context.userAuthToken (omitido quando ausente) em um único ponto do FileManager, e adicionar 4 novas operações GraphQL como proxy fino de /policies/* do file-manager, sem lógica de permissão própria.</div>
+      </div>
+      <div class="tldr-item">
+        <div class="tldr-bullet b-constraint">⚠</div>
+        <div><strong>Dependência bloqueante:</strong> a US-1 (token forwarding) é pré-requisito explícito do gate de ativação da US-4 do <code style="font-size:11px;opacity:.8">vtex.file-manager</code> — sem ela, todo tráfego proxied seria tratado como anônimo.</div>
+      </div>
+      <div class="tldr-item">
+        <div class="tldr-bullet b-scope">📦</div>
+        <div><strong>Fora de escopo:</strong> mudanças dentro do próprio file-manager, POST /policies/{bucket}/manifest (exclusiva do builder-hub), UI do Admin Panel (Fase 10), e ativação da US-4 em produção (decidida pelo time do file-manager).</div>
+      </div>
+    </div>
+
+    <div style="font-size:12px;color:var(--muted);font-weight:600;text-transform:uppercase;letter-spacing:.07em;margin-bottom:12px">Fluxo de encaminhamento de token e proxy de política</div>
+    <div class="chain-wrap">
+      <div class="chain-node">
+        <div class="chain-num">1</div>
+        <div class="chain-name">Resolvers de arquivo</div>
+        <div class="chain-detail">getFile / uploadFile / deleteFile encaminham <code style="font-size:10px">userAuthToken</code> (ou omitem o header).</div>
+      </div>
+      <div class="chain-arrow">→</div>
+      <div class="chain-node">
+        <div class="chain-num">2</div>
+        <div class="chain-name">FileManager (ExternalClient)</div>
+        <div class="chain-detail">Único ponto de construção do header — herdado por toda operação, incluindo as novas de política.</div>
+      </div>
+      <div class="chain-arrow">→</div>
+      <div class="chain-node">
+        <div class="chain-num">3</div>
+        <div class="chain-name">vtex.file-manager</div>
+        <div class="chain-detail">Classifica anônimo/autenticado/admin corretamente; decide 403 para /policies/*.</div>
+      </div>
+      <div class="chain-arrow">→</div>
+      <div class="chain-node">
+        <div class="chain-num">4</div>
+        <div class="chain-name">Resolvers de política</div>
+        <div class="chain-detail">403 do file-manager é repassado ao caller GraphQL sem alteração.</div>
+      </div>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- 2. User Stories -->
+  <section class="panel" id="stories">
+    <div class="panel-eyebrow">Business Context</div>
+    <div class="panel-title">User Stories</div>
+    <div class="panel-sub">3 stories: correção do encaminhamento de token (bloqueante para o file-manager) e a superfície GraphQL de leitura/escrita de política de bucket.</div>
+
+    <div class="story-grid">
+
+      <div class="story-card" onclick="toggleStory(this)">
+        <div class="story-header">
+          <div class="story-tag">US-1</div>
+          <div class="story-title">Encaminhar o token real do usuário em toda operação de arquivo</div>
+        </div>
+        <div class="story-role">Como enforcement do file-manager <span style="font-size:11px;color:var(--amber)"> · Bloqueante</span></div>
+        <div class="story-expand">Ver critérios de aceite ↓</div>
+        <div class="story-acs">
+          <div class="story-ac"><code style="font-size:11px">VtexIdclientAutCookie</code> passa a carregar <code style="font-size:11px">context.userAuthToken</code>, não <code style="font-size:11px">context.authToken</code>, em getFile/getFileUrl/uploadFile/deleteFile.</div>
+          <div class="story-ac">Sem token de usuário, o header é omitido — nunca enviado vazio.</div>
+          <div class="story-ac">Isenção da allow list para uploadFile permanece inalterada.</div>
+          <div class="story-ac">Mudança única no constructor de FileManager, compartilhada por toda operação de arquivo.</div>
+        </div>
+      </div>
+
+      <div class="story-card" onclick="toggleStory(this)">
+        <div class="story-header">
+          <div class="story-tag">US-2</div>
+          <div class="story-title">Ler políticas de bucket via GraphQL</div>
+        </div>
+        <div class="story-role">Como administrador de conta</div>
+        <div class="story-expand">Ver critérios de aceite ↓</div>
+        <div class="story-acs">
+          <div class="story-ac"><code style="font-size:11px">listBucketPolicies</code> faz proxy de GET /policies, paginando o nextMarker internamente — o caller recebe uma lista única e completa.</div>
+          <div class="story-ac"><code style="font-size:11px">getBucketPolicy(bucket)</code> faz proxy de GET /policies/{bucket}.</div>
+          <div class="story-ac">403 sem o resource file-manager-bucket-config é exposto como está — sem checagem própria nesta app.</div>
+        </div>
+      </div>
+
+      <div class="story-card" onclick="toggleStory(this)">
+        <div class="story-header">
+          <div class="story-tag">US-3</div>
+          <div class="story-title">Escrever e remover a política admin de um bucket via GraphQL</div>
+        </div>
+        <div class="story-role">Como administrador de conta</div>
+        <div class="story-expand">Ver critérios de aceite ↓</div>
+        <div class="story-acs">
+          <div class="story-ac"><code style="font-size:11px">setBucketPolicy</code>/<code style="font-size:11px">deleteBucketPolicy</code> fazem proxy de POST/DELETE /policies/{bucket}/admin.</div>
+          <div class="story-ac">Buckets protegidos retornam o 403 "bucket policy is immutable" do file-manager sem alteração.</div>
+          <div class="story-ac">POST /policies/{bucket}/manifest nunca é exposta via GraphQL — exclusiva do builder-hub.</div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- 3. Arquitetura -->
+  <section class="panel" id="architecture">
+    <div class="panel-eyebrow">Arch Decisions</div>
+    <div class="panel-title">Arquitetura</div>
+    <div class="panel-sub">Duas mudanças aditivas ao ExternalClient FileManager já existente — nenhum client novo, nenhuma camada de autorização própria adicional.</div>
+
+    <div class="arch-section-title">Decisões de escopo</div>
+    <div style="background:var(--surface);border:1px solid var(--border);border-radius:12px;overflow:hidden">
+      <table class="policy-table">
+        <thead>
+          <tr><th>Aspecto</th><th>Decisão</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Header ausente</td>
+            <td>Omitido, nunca enviado vazio <span style="font-size:11px;color:var(--muted)">(D1)</span></td>
+          </tr>
+          <tr>
+            <td>Onde vivem os métodos /policies/*</td>
+            <td>No FileManager existente, não um client novo <span style="font-size:11px;color:var(--muted)">(D2)</span></td>
+          </tr>
+          <tr>
+            <td>Erros do downstream (incl. 403)</td>
+            <td>Relançados como estão — sem wrapper genérico <span style="font-size:11px;color:var(--muted)">(D3)</span></td>
+          </tr>
+          <tr>
+            <td>Autorização extra (Sphinx)</td>
+            <td>Não adicionada — LicenseManager do file-manager já decide <span style="font-size:11px;color:var(--muted)">(D4)</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- 4. Key Decisions -->
+  <section class="panel" id="decisions">
+    <div class="panel-eyebrow">Arch Decisions</div>
+    <div class="panel-title">Key Decisions</div>
+    <div class="panel-sub">4 decisões arquiteturais documentadas — todas aceitas, sem pendência de validação externa.</div>
+
+    <div class="decisions-list">
+
+      <div class="decision-card" onclick="toggleDecision(this)">
+        <div class="decision-header">
+          <div class="decision-n">1</div>
+          <div class="decision-title">Omitir o header em vez de enviar token vazio/undefined</div>
+          <div class="decision-status">Accepted</div>
+          <div class="decision-chevron">▾</div>
+        </div>
+        <div class="decision-body">
+          <div class="decision-field"><strong>Decisão:</strong> O constructor do FileManager só inclui VtexIdclientAutCookie quando context.userAuthToken é truthy; ausente, a chave do header é omitida, não enviada vazia.</div>
+          <div class="decision-field"><strong>Consequência:</strong> Alinha-se exatamente com a detecção de anônimo do file-manager — evita ambiguidade entre "header presente mas vazio" e "header ausente".</div>
+        </div>
+      </div>
+
+      <div class="decision-card" onclick="toggleDecision(this)">
+        <div class="decision-header">
+          <div class="decision-n">2</div>
+          <div class="decision-title">Métodos /policies/* vivem no FileManager existente</div>
+          <div class="decision-status">Accepted</div>
+          <div class="decision-chevron">▾</div>
+        </div>
+        <div class="decision-body">
+          <div class="decision-field"><strong>Decisão:</strong> listPolicies, getPolicy, setAdminPolicy, deleteAdminPolicy são novos métodos públicos no FileManager já existente, reaproveitando constructor e header.</div>
+          <div class="decision-field"><strong>Consequência:</strong> Mantém uma única fonte de verdade de comunicação com o file-manager; herdam automaticamente o comportamento corrigido de token da D1.</div>
+        </div>
+      </div>
+
+      <div class="decision-card" onclick="toggleDecision(this)">
+        <div class="decision-header">
+          <div class="decision-n">3</div>
+          <div class="decision-title">Erros do downstream (incl. 403) são relançados como estão</div>
+          <div class="decision-status">Accepted</div>
+          <div class="decision-chevron">▾</div>
+        </div>
+        <div class="decision-body">
+          <div class="decision-field"><strong>Decisão:</strong> /policies/* segue o padrão de getFile/deleteFile (relançar como está), não o de saveFile (InternalServerError genérico).</div>
+          <div class="decision-field"><strong>Consequência:</strong> Admin Panel recebe o motivo exato da rejeição (ex.: "bucket policy is immutable"), em vez de uma falha genérica.</div>
+        </div>
+      </div>
+
+      <div class="decision-card" onclick="toggleDecision(this)">
+        <div class="decision-header">
+          <div class="decision-n">4</div>
+          <div class="decision-title">Sem camada nova de Sphinx/@requiresAuth além do login</div>
+          <div class="decision-status">Accepted</div>
+          <div class="decision-chevron">▾</div>
+        </div>
+        <div class="decision-body">
+          <div class="decision-field"><strong>Decisão:</strong> @requiresAuth continua exigindo login, mas a decisão de account-administrator é inteiramente do LicenseManager do file-manager — sem checagem Sphinx duplicada.</div>
+          <div class="decision-field"><strong>Consequência:</strong> Evita duas fontes de autorização potencialmente inconsistentes.</div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- 5. Riscos -->
+  <section class="panel" id="risks">
+    <div class="panel-eyebrow">Arch Decisions</div>
+    <div class="panel-title">Riscos</div>
+    <div class="panel-sub">3 riscos mapeados. Nenhum bloqueia o deploy independente desta spec.</div>
+
+    <div class="risk-grid">
+
+      <div class="risk-card">
+        <div class="risk-badges">
+          <span class="badge-impact low">Nenhum impacto</span>
+          <span class="badge-likelihood high">Alta prob.</span>
+        </div>
+        <div class="risk-title">US-1 é lançada antes da ativação da US-4 do file-manager</div>
+        <div class="risk-mitigation"><strong>Mitigação:</strong> Seguro deployar de forma independente — sem efeito comportamental até a ativação.</div>
+      </div>
+
+      <div class="risk-card">
+        <div class="risk-badges">
+          <span class="badge-impact medium">Médio impacto</span>
+          <span class="badge-likelihood low">Baixa prob.</span>
+        </div>
+        <div class="risk-title">Algum caller dependia implicitamente do token de app dar acesso elevado</div>
+        <div class="risk-mitigation"><strong>Mitigação:</strong> Coberto pelo risco de ativação do próprio file-manager; esta spec só corrige o tipo de token enviado.</div>
+      </div>
+
+      <div class="risk-card">
+        <div class="risk-badges">
+          <span class="badge-impact low">Baixo impacto</span>
+          <span class="badge-likelihood medium">Média prob.</span>
+        </div>
+        <div class="risk-title">Resolvers /policies/* ficam fora de sincronia com o schema do file-manager</div>
+        <div class="risk-mitigation"><strong>Mitigação:</strong> Pin de versão vtex.file-manager: 0.x já existente; mudanças passam por revisão própria.</div>
+      </div>
+
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- 6. Superfície GraphQL -->
+  <section class="panel" id="api">
+    <div class="panel-eyebrow">Technical Contract</div>
+    <div class="panel-title">Superfície GraphQL</div>
+    <div class="panel-sub">4 novas operações, todas com @requiresAuth. Autorização de nível admin decidida inteiramente pelo file-manager (LicenseManager) — sem lógica própria nesta app.</div>
+
+    <div class="endpoint-list">
+
+      <div class="endpoint">
+        <div class="method m-get">QUERY</div>
+        <div>
+          <div class="endpoint-path">listBucketPolicies</div>
+          <div class="endpoint-desc">Proxy paginado de <code style="font-size:11px">GET /policies</code> — retorna todo bucket configurado na conta do caller, com effectivePolicy, manifestPolicy e adminPolicy.</div>
+          <div class="endpoint-codes">
+            <span class="code-badge c200">lista completa</span>
+            <span class="code-badge c403">403 sem file-manager-bucket-config</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="endpoint">
+        <div class="method m-get">QUERY</div>
+        <div>
+          <div class="endpoint-path">getBucketPolicy(bucket)</div>
+          <div class="endpoint-desc">Proxy de <code style="font-size:11px">GET /policies/{bucket}</code> — null para fontes não configuradas.</div>
+          <div class="endpoint-codes">
+            <span class="code-badge c200">200</span>
+            <span class="code-badge c403">403 sem permissão</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="endpoint">
+        <div class="method m-post">MUTATION</div>
+        <div>
+          <div class="endpoint-path">setBucketPolicy(bucket, readAccess, writeAccess)</div>
+          <div class="endpoint-desc">Proxy de <code style="font-size:11px">POST /policies/{bucket}/admin</code>.</div>
+          <div class="endpoint-codes">
+            <span class="code-badge c200">política gravada</span>
+            <span class="code-badge c403">403 bucket imutável</span>
+            <span class="code-badge c403">403 sem permissão</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="endpoint">
+        <div class="method m-delete">MUTATION</div>
+        <div>
+          <div class="endpoint-path">deleteBucketPolicy(bucket)</div>
+          <div class="endpoint-desc">Proxy de <code style="font-size:11px">DELETE /policies/{bucket}/admin</code>.</div>
+          <div class="endpoint-codes">
+            <span class="code-badge c200">confirmação</span>
+            <span class="code-badge c403">403 bucket imutável</span>
+            <span class="code-badge c403">403 sem permissão</span>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- 7. Gap -->
+  <section class="panel" id="gap">
+    <div class="panel-eyebrow">Resultado do review</div>
+    <div class="panel-title">Conformidade</div>
+    <div class="panel-sub">17/18 itens conformes com o template specification + sdlc-golden-path. Todas as 17 seções do template SDD estão presentes e preenchidas. 1 gap obrigatório do golden path permanece.</div>
+
+    <div class="gap-card">
+      <div class="gap-label">⚠ Ação requerida · sdlc-golden-path · NFR gate</div>
+      <div class="gap-title">NFR Observability ausente</div>
+      <div class="gap-body">
+        A feature adiciona 4 novas operações GraphQL e um novo padrão de encaminhamento de credencial — o <code style="font-size:12px;background:rgba(0,0,0,.3);padding:1px 5px;border-radius:4px">sdlc-golden-path</code> exige ao menos um NFR referenciando o O11y golden path, ou um waiver explícito com justificativa. A seção Non-Functional Requirements atual cobre apenas política de rede (sem novo outbound-access) e reuso de infraestrutura — sem menção a logging, tracing ou métricas de erro para as novas operações /policies/*.
+      </div>
+      <div class="gap-fix">Adicionar à seção NFR:
+
+NFR-O11y: Logging estruturado (sem PII) em toda operação
+/policies/*, incluindo bucket e resultado (200/403); nenhuma
+tracing span nova é necessária além da já emitida pelo
+ExternalClient subjacente.
+
+— ou, se realmente não se aplicar —
+
+NFR-O11y: N/A — [justificativa aqui]</div>
+    </div>
+
+  </section>
+
+</main>
+
+<script>
+const sections = ['overview','stories','architecture','decisions','risks','api','gap'];
+const visited = new Set();
+
+// Scroll progress bar
+window.addEventListener('scroll', () => {
+  const doc = document.documentElement;
+  const scrolled = doc.scrollTop / (doc.scrollHeight - doc.clientHeight);
+  document.getElementById('reading-fill').style.width = (scrolled * 100) + '%';
+});
+
+// IntersectionObserver for nav state
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      const id = entry.target.id;
+      visited.add(id);
+      updateNav(id);
+    }
+  });
+}, { rootMargin: '-20% 0px -60% 0px', threshold: 0 });
+
+sections.forEach(id => {
+  const el = document.getElementById(id);
+  if (el) observer.observe(el);
+});
+
+function updateNav(activeId) {
+  document.querySelectorAll('.nav-item').forEach(item => {
+    const t = item.dataset.target;
+    item.classList.toggle('active', t === activeId);
+    if (visited.has(t)) item.classList.add('visited');
+  });
+
+  const count = visited.size;
+  const pct = (count / sections.length * 100).toFixed(0);
+  document.getElementById('nav-fill').style.width = pct + '%';
+  document.getElementById('nav-count').textContent = `${count} / ${sections.length} seções`;
+}
+
+// Nav click smooth scroll
+document.querySelectorAll('.nav-item').forEach(item => {
+  item.addEventListener('click', () => {
+    const el = document.getElementById(item.dataset.target);
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  });
+});
+
+// Story cards
+function toggleStory(card) {
+  card.classList.toggle('open');
+  const expand = card.querySelector('.story-expand');
+  if (expand) expand.textContent = card.classList.contains('open') ? 'Fechar ↑' : 'Ver critérios de aceite ↓';
+}
+
+// Decision cards
+function toggleDecision(card) {
+  card.classList.toggle('open');
+}
+</script>
+</body>
+</html>

--- a/specs/review-bucket-access-control-integration.md
+++ b/specs/review-bucket-access-control-integration.md
@@ -1,0 +1,205 @@
+<!--
+  Review interativo da spec `bucket-access-control-integration.md`.
+  Gerado a partir da spec + do canvas HTML (specs/review-bucket-access-control-integration.html).
+  Este arquivo é feito para ser lido dentro do GitHub (PR/arquivo) — usa <details> nativo,
+  tabelas e mermaid, que o GitHub já renderiza sem precisar de HTML/JS custom.
+  Se a spec mudar, regenere este arquivo — não edite o HTML à mão para refletir mudanças daqui.
+-->
+
+# 🧭 Bucket Access Control Integration — Review
+
+**Draft** · `STR-773` · Fases 4, 9 · 3 User Stories · 4 Key Decisions · ✅ revisado 2026-08-07
+
+> Encaminhamento correto de token de usuário e superfície GraphQL de política de bucket no
+> `file-manager-graphql`. Este review resume a spec completa em
+> [`bucket-access-control-integration.md`](./bucket-access-control-integration.md) — clique nas
+> seções abaixo para expandir.
+
+---
+
+## 📋 TL;DR
+
+| | |
+|---|---|
+| 🔓 **Problema** | O `file-manager-graphql` hoje encaminha `context.authToken` (token da própria app) em toda chamada ao file-manager — isso impede o file-manager de distinguir anônimo/autenticado/admin, e vai rejeitar em massa o tráfego via Admin Panel/store-form quando o enforcement for ativado. |
+| 🔧 **Solução** | Trocar a origem do header `VtexIdclientAutCookie` para `context.userAuthToken` (omitido quando ausente) em um único ponto do `FileManager`, e adicionar 4 novas operações GraphQL como proxy fino de `/policies/*` do file-manager, sem lógica de permissão própria. |
+| ⚠️ **Dependência bloqueante** | A US-1 (token forwarding) é pré-requisito explícito do gate de ativação da US-4 do `vtex.file-manager` — sem ela, todo tráfego proxied seria tratado como anônimo. |
+| 📦 **Fora de escopo** | Mudanças dentro do próprio file-manager, `POST /policies/{bucket}/manifest` (exclusiva do builder-hub), UI do Admin Panel (Fase 10), e ativação da US-4 em produção (decidida pelo time do file-manager). |
+
+### Fluxo de encaminhamento de token e proxy de política
+
+```mermaid
+flowchart LR
+    A["Resolvers de arquivo<br/>getFile / uploadFile / deleteFile"] -->|"VtexIdclientAutCookie:<br/>userAuthToken (ou omitido)"| B["FileManager (ExternalClient)"]
+    C["Resolvers de política<br/>listBucketPolicies / setBucketPolicy"] -->|"VtexIdclientAutCookie:<br/>userAuthToken"| B
+    B -->|"HTTP"| D["vtex.file-manager"]
+    D -->|"403 como está"| C
+```
+
+---
+
+## 📖 User Stories
+
+<details>
+<summary><b>US-1</b> — Encaminhar o token real do usuário em toda operação de arquivo <sub>como enforcement do file-manager · ⚠️ bloqueante</sub></summary>
+
+- `VtexIdclientAutCookie` passa a carregar `context.userAuthToken`, não `context.authToken`, em `getFile`, `getFileUrl`, `uploadFile`, `deleteFile`.
+- Quando não há token de usuário, o header é omitido — nunca enviado vazio.
+- Isenção da allow list (`config/allowList.ts`) para `uploadFile` permanece inalterada.
+- Mudança única no constructor de `FileManager`, compartilhada por toda operação de arquivo.
+
+</details>
+
+<details>
+<summary><b>US-2</b> — Ler políticas de bucket via GraphQL <sub>como administrador de conta</sub></summary>
+
+- `listBucketPolicies` faz proxy de `GET /policies`, paginando o `nextMarker` internamente até esgotar — o caller GraphQL recebe uma lista única e completa.
+- `getBucketPolicy(bucket)` faz proxy de `GET /policies/{bucket}`.
+- `403` sem o resource `file-manager-bucket-config` é exposto como está — sem checagem de permissão própria nesta app.
+
+</details>
+
+<details>
+<summary><b>US-3</b> — Escrever e remover a política admin de um bucket via GraphQL <sub>como administrador de conta</sub></summary>
+
+- `setBucketPolicy`/`deleteBucketPolicy` fazem proxy de `POST`/`DELETE /policies/{bucket}/admin`.
+- Buckets protegidos (`vtex-assets-builder`, `vtex.catalog-images-products`, `vtex.file-manager-graphql-logo`) retornam o `403 "bucket policy is immutable"` do file-manager sem alteração.
+- `POST /policies/{bucket}/manifest` nunca é exposta via GraphQL — exclusiva do builder-hub.
+
+</details>
+
+---
+
+## 🏗️ Arquitetura
+
+Duas mudanças aditivas ao `ExternalClient` `FileManager` já existente — nenhum client novo,
+nenhuma camada de autorização própria adicional.
+
+### Tabela de decisões de escopo
+
+| Aspecto | Decisão |
+|---|---|
+| Header ausente | Omitido, nunca enviado vazio (Decision 1) |
+| Onde vivem os métodos `/policies/*` | No `FileManager` existente, não um client novo (Decision 2) |
+| Erros do downstream (incl. 403) | Relançados como estão — sem wrapper genérico (Decision 3) |
+| Autorização extra (Sphinx) | Não adicionada — LicenseManager do file-manager já decide (Decision 4) |
+
+---
+
+## 🔑 Key Decisions
+
+<details>
+<summary><b>D1</b> · <code>Accepted</code> — Omitir o header em vez de enviar token vazio/undefined</summary>
+
+**Decisão:** O constructor do `FileManager` só inclui `VtexIdclientAutCookie` quando `context.userAuthToken` é truthy; ausente, a chave do header é omitida, não enviada vazia.
+
+**Consequência:** Alinha-se exatamente com a detecção de anônimo do file-manager — evita ambiguidade entre "header presente mas vazio" e "header ausente".
+
+</details>
+
+<details>
+<summary><b>D2</b> · <code>Accepted</code> — Métodos <code>/policies/*</code> vivem no <code>FileManager</code> existente</summary>
+
+**Decisão:** `listPolicies`, `getPolicy`, `setAdminPolicy`, `deleteAdminPolicy` são novos métodos públicos no `FileManager` já existente, reaproveitando constructor e header.
+
+**Consequência:** Mantém uma única fonte de verdade de comunicação com o file-manager; herdam automaticamente o comportamento corrigido de token da D1.
+
+</details>
+
+<details>
+<summary><b>D3</b> · <code>Accepted</code> — Erros do downstream (incl. 403) são relançados como estão</summary>
+
+**Decisão:** `/policies/*` segue o padrão de `getFile`/`deleteFile` (relançar como está), não o de `saveFile` (`InternalServerError` genérico).
+
+**Consequência:** Admin Panel recebe o motivo exato da rejeição (ex.: `"bucket policy is immutable"`), em vez de uma falha genérica.
+
+</details>
+
+<details>
+<summary><b>D4</b> · <code>Accepted</code> — Sem camada nova de Sphinx/<code>@requiresAuth</code> além do login</summary>
+
+**Decisão:** `@requiresAuth` continua exigindo login, mas a decisão de account-administrator é inteiramente do LicenseManager do file-manager — sem checagem Sphinx duplicada.
+
+**Consequência:** Evita duas fontes de autorização potencialmente inconsistentes.
+
+</details>
+
+---
+
+## ⚠️ Riscos
+
+| Risco | Impacto | Probabilidade | Mitigação |
+|---|---|---|---|
+| US-1 é lançada antes da ativação da US-4 do file-manager | Nenhum | Alta (esperado) | Seguro deployar de forma independente — sem efeito comportamental até a ativação |
+| Algum caller dependia implicitamente do token de app dar acesso elevado | Médio | Baixa | Coberto pelo risco de ativação do próprio file-manager; esta spec só corrige o tipo de token enviado |
+| Resolvers `/policies/*` ficam fora de sincronia com o schema do file-manager | Baixo | Média | Pin de versão `vtex.file-manager: 0.x` já existente; mudanças passam por revisão própria |
+
+---
+
+## 🔌 Superfície GraphQL
+
+4 novas operações, todas com `@requiresAuth`. Autorização de nível admin decidida inteiramente
+pelo file-manager (LicenseManager) — sem lógica própria nesta app.
+
+<details open>
+<summary><code>QUERY</code> <b>listBucketPolicies</b></summary>
+
+Proxy paginado de `GET /policies` — retorna todo bucket configurado na conta do caller, com `effectivePolicy`, `manifestPolicy` e `adminPolicy`.
+
+`200` lista completa · `403` sem `file-manager-bucket-config`
+
+</details>
+
+<details>
+<summary><code>QUERY</code> <b>getBucketPolicy(bucket)</b></summary>
+
+Proxy de `GET /policies/{bucket}` — `null` para fontes não configuradas.
+
+`200` · `403` sem permissão
+
+</details>
+
+<details>
+<summary><code>MUTATION</code> <b>setBucketPolicy(bucket, readAccess, writeAccess)</b></summary>
+
+Proxy de `POST /policies/{bucket}/admin`.
+
+`200` política gravada · `403` bucket imutável · `403` sem permissão
+
+</details>
+
+<details>
+<summary><code>MUTATION</code> <b>deleteBucketPolicy(bucket)</b></summary>
+
+Proxy de `DELETE /policies/{bucket}/admin`.
+
+`200` confirmação · `403` bucket imutável · `403` sem permissão
+
+</details>
+
+---
+
+## ✅ Resultado do review
+
+**17/18 itens conformes** com o template `specification` + `sdlc-golden-path`. Todas as 17
+seções do template SDD (Problem Statement, Goals, User Stories com ACs, Key Scenarios,
+Functional/Non-Functional Requirements, Out of Scope, Proposed Solution, Architecture Overview,
+Alternatives Considered, Risks & Mitigations, Key Decisions, Implementation Plan, Data Models,
+Interfaces, Integration Points, Invariants & Constraints) estão presentes e preenchidas. 1 gap
+obrigatório do golden path permanece.
+
+> ⚠ **Ação requerida · sdlc-golden-path · NFR gate — NFR Observability ausente**
+>
+> A feature adiciona 4 novas operações GraphQL e um novo padrão de encaminhamento de credencial —
+> o `sdlc-golden-path` exige ao menos um NFR referenciando o O11y golden path, ou um waiver
+> explícito com justificativa. A seção Non-Functional Requirements atual cobre apenas política de
+> rede (sem novo `outbound-access`) e reuso de infraestrutura — sem menção a logging, tracing ou
+> métricas de erro para as novas operações `/policies/*`.
+>
+> **Fix sugerido**, adicionar à seção NFR:
+> ```
+> NFR-O11y: Logging estruturado (sem PII) em toda operação /policies/*,
+> incluindo bucket e resultado (200/403); nenhuma tracing span nova é
+> necessária além da já emitida pelo ExternalClient subjacente.
+> ```
+> — ou, se realmente não se aplicar, `NFR-O11y: N/A — [justificativa]`.


### PR DESCRIPTION
## Summary

Adds the SDD spec for `file-manager-graphql`'s part of the `vtex.file-manager` per-bucket access control rollout ([RFC](https://github.com/vtex/file-manager) / cross-repo rollout plan):

- **Token forwarding**: `FileManager` (ExternalClient) must forward the real end-user token (`context.userAuthToken`) instead of the app token (`context.authToken`) on every file operation, omitting the `VtexIdclientAutCookie` header entirely when the caller is anonymous, so `vtex.file-manager` can correctly classify the caller for access control.
- **Bucket policy management via GraphQL**: new `listBucketPolicies`, `getBucketPolicy`, `setBucketPolicy`, and `deleteBucketPolicy` operations that proxy `vtex.file-manager`'s new `/policies/*` REST APIs, with no additional permission logic on this layer — downstream errors (including `403` on the 3 protected buckets) are surfaced to the caller unchanged.

Includes the spec itself plus its review artifacts (markdown and HTML), following the existing `specification`/review skill format used across the org.

## Files

- `specs/bucket-access-control-integration.md` — the spec (Business Context, Arch Decisions, Technical Contract)
- `specs/review-bucket-access-control-integration.md` / `.html` — structured review of the spec (conformance score, key decisions, risks, API surface)

## Test plan

- [ ] Docs-only change — no code included in this PR
- [ ] Review spec content against the `vtex.file-manager` RFC and confirm scope matches Phase 4 of the cross-repo rollout plan
